### PR TITLE
Handle anonymous users in index view

### DIFF
--- a/sales/views.py
+++ b/sales/views.py
@@ -370,8 +370,13 @@ def index(request):
     user = request.user
     print(f"Total properties: {Property.objects.count()}")  # Debug count
 
-    liked_ids = list(Property.objects.filter(likes=user).values_list('id', flat=True))
-    disliked_ids = list(Property.objects.filter(dislikes=user).values_list('id', flat=True))
+    # Anonymous users do not have id for ManyToMany lookups
+    if user.is_authenticated:
+        liked_ids = list(Property.objects.filter(likes=user).values_list('id', flat=True))
+        disliked_ids = list(Property.objects.filter(dislikes=user).values_list('id', flat=True))
+    else:
+        liked_ids = []
+        disliked_ids = []
 
     print(f"Liked IDs: {liked_ids}")  # Debug liked
     print(f"Disliked IDs: {disliked_ids}")  # Debug disliked


### PR DESCRIPTION
## Summary
- prevent server error for anonymous users by checking `request.user.is_authenticated`

## Testing
- `pytest -q`
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688bd8f5f50c832e98ad13953779e737