### PR TITLE
Hide filter form initially

### DIFF
--- a/sales/templates/sales/partials/filter_form.html
+++ b/sales/templates/sales/partials/filter_form.html
@@ -1,6 +1,6 @@
 {% block filter %}
 <!-- Filter Form Container -->
-<div id="filter-form-container" class="filter-form-container">
+<div id="filter-form-container" class="filter-form-container hidden">
     <div class="filter-form-content">
         <form id="filter-form" class="filter-form" method="GET" action="{% url 'sales:filter_properties' %}">
             <div class="filter-column">


### PR DESCRIPTION
## Summary
- hide the filter form by default so it only appears after using the toggle

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688bdbc55280832e9859906b52717cf7