### PR TITLE
Fix property tab default visibility

### DIFF
--- a/sales/templates/sales/index.html
+++ b/sales/templates/sales/index.html
@@ -28,7 +28,7 @@
   </div>
 
   <!-- Aba Novos -->
-  <div id="new" class="property-tab">
+  <div id="new" class="property-tab hidden">
     <h4 class="mb-3">🆕 Novos Imóveis</h4>
     <div class="properties-container" id="container-new">
       {% for property in imos %}


### PR DESCRIPTION
## Summary
- hide property listing tabs by default so no cards show on initial page load

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688bdd01b4fc832eb9d592638d31d30f