### PR TITLE
Remove hardcoded email credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Ignore Python virtual environments
+juliana/bin/
+juliana/Lib/
+juliana/lib/
+juliana/lib64/
+juliana/Scripts/
+juliana/pyvenv.cfg
+
+# Bytecode
+__pycache__/
+*.pyc
+
+# SQLite database
+*.sqlite3

--- a/juliana/settings.py
+++ b/juliana/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -92,13 +93,13 @@ MIDDLEWARE = [
 
 
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'lukemarki3@gmail.com'
-EMAIL_HOST_PASSWORD = 'meus3e33'
-DEFAULT_FROM_EMAIL = 'lukemarki3@gmail.com'
+EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
+EMAIL_HOST = os.getenv('EMAIL_HOST', 'smtp.gmail.com')
+EMAIL_PORT = int(os.getenv('EMAIL_PORT', '587'))
+EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', 'True') == 'True'
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
 
 
 
@@ -174,8 +175,6 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-
-import os
 
 # settings.py
 


### PR DESCRIPTION
## Summary
- remove plaintext email credentials by sourcing from env vars
- ignore virtualenv files

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688bfe968580832e92411d0b4c6e171d