### PR TITLE
Fix root URL conflict

### DIFF
--- a/juliana/urls.py
+++ b/juliana/urls.py
@@ -17,7 +17,6 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.conf.urls.static import static
-from django.shortcuts import redirect
 
 
 urlpatterns = [
@@ -27,7 +26,6 @@ urlpatterns = [
 
     # Include Allauth URLs
     path('accounts/', include('allauth.urls')),
-    path('', lambda request: redirect('accounts/login/')),  # Redirect root URL to login
     
 ] 
 


### PR DESCRIPTION
## Summary
- remove duplicate root URL redirect

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688bfe780a48832e976b238dc311a8d0