### PR TITLE
Fix disabled details link and update image modal

### DIFF
--- a/sales/templates/sales/painel_juridico.html
+++ b/sales/templates/sales/painel_juridico.html
@@ -14,7 +14,7 @@
           <p><strong>Valor da proposta:</strong> R$ {{ acordo.bid.amount }}</p>
           <p><strong>Status:</strong> {{ acordo.status }}</p>
           <p><strong>Data:</strong> {{ acordo.date_closed|date:"d/m/Y H:i" }}</p>
-          <a href="#" class="btn btn-outline-primary disabled">Ver detalhes (em breve)</a>
+          <a href='{% url 'sales:acordo_detalhes' acordo.id %}' class='btn btn-outline-primary'>Ver detalhes</a>
         </div>
       </div>
     {% endfor %}

--- a/sales/templates/sales/partials/property_card.html
+++ b/sales/templates/sales/partials/property_card.html
@@ -296,14 +296,12 @@ function initPropertyCards() {
     const thumb = e.target.closest('.property-thumbnail');
     if (thumb) {
       const images = JSON.parse(thumb.getAttribute('data-images'));
-      openImageCarousel(images);
+      if (typeof openFullscreen === "function") {
+        openFullscreen(thumb);
+      } else if (typeof openFullscreenModal === "function") {
+        openFullscreenModal(thumb);
+      }
     }
   });
 }
 
-function openImageCarousel(images) {
-  // Your existing carousel implementation
-  console.log('Opening carousel with images:', images);
-  // Implement your fullscreen carousel logic here
-}
-</script>

--- a/sales/views.py
+++ b/sales/views.py
@@ -9,8 +9,6 @@ from .forms import BidForm, PropertyForm, PropertyImageFormSet, DealStepForm
 from django.core.exceptions import ValidationError
 from django.contrib import messages
 
-from django.db.models import Q
-from django.http import JsonResponse
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -149,16 +147,6 @@ def painel_juridico(request):
 def create_user_profile(sender, instance, created, **kwargs):
     if created:
         UserProfile.objects.create(user=instance)
-
-@login_required
-def painel_juridico(request):
-    if not hasattr(request.user, 'userprofile') or request.user.userprofile.role != 'advogada':
-        return redirect('sales:index')  # ou 403 Forbidden
-
-    # Se chegou aqui, é advogada
-    acordos = Deal.objects.all()
-    return render(request, 'sales/painel_juridico.html', {'acordos': acordos})
-
 
 
 @login_required
@@ -359,11 +347,6 @@ def filter_properties(request):
 
 
 
-
-from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, get_object_or_404, redirect
-from .models import Property, Bid
-from .forms import BidForm
 
 # In your views.py, verify the queries
 def index(request):


### PR DESCRIPTION
## Summary
- enable viewing deal details in the juridical panel
- open property images using the existing modal logic
- remove unused imports and duplicate view function

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c01d1f058832eb59b0a83863f47cb