### PR TITLE
Fix tab switching in property page

### DIFF
--- a/sales/templates/sales/index.html
+++ b/sales/templates/sales/index.html
@@ -376,7 +376,8 @@
   let currentImageIndex = 0;
   let isModalOpen = false;
 
-  document.addEventListener('DOMContentLoaded', () => {
+  // Run setup immediately because this script is placed after the HTML
+  // content and the DOM is already loaded when it executes.
     /* --------- Alternar abas --------- */
     document.querySelectorAll('.tab-btn').forEach(btn => {
       btn.addEventListener('click', () => {
@@ -466,7 +467,6 @@
         showImage(currentImageIndex + 1);
       }
     });
-  });
 
   /* ---------- helpers ---------- */
   function moveCard(id, target) {


### PR DESCRIPTION
## Summary
- make tab switching JS run immediately so DOMContentLoaded isn't missed

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c06ea262c832ea520203d439f0991