### PR TITLE
Fix multi-image upload form widget

### DIFF
--- a/sales/forms.py
+++ b/sales/forms.py
@@ -2,6 +2,12 @@ from django import forms
 from .models import Bid, Property, PropertyImage, DealStep
 from django.forms.models import inlineformset_factory
 
+
+class ClearableMultipleFileInput(forms.ClearableFileInput):
+    """Allow selecting multiple files in a clearable file input."""
+
+    allow_multiple_selected = True
+
 class DealStepForm(forms.ModelForm):
     class Meta:
         model = DealStep
@@ -27,7 +33,7 @@ class BidForm(forms.ModelForm):
 
 class PropertyForm(forms.ModelForm):
     images = forms.ImageField(
-        widget=forms.ClearableFileInput(attrs={'multiple': True}),
+        widget=ClearableMultipleFileInput(),
         required=False,
         label="Fotos do Imóvel"
     )


### PR DESCRIPTION
## Summary
- allow multiple file upload using a custom ClearableFileInput subclass

## Testing
- `python3 manage.py test` *(fails: cannot import `cryptography` due to incompatible packages)*

------
https://chatgpt.com/codex/tasks/task_e_688c099adc64832eb86abaa9d3604d18